### PR TITLE
Fix scroll decoder

### DIFF
--- a/src/InfiniteList.elm
+++ b/src/InfiniteList.elm
@@ -547,7 +547,7 @@ computeElementsAndSizesForMultipleHeights (Config { offset, containerHeight }) g
 
 decodeToModel : JD.Decoder Model
 decodeToModel =
-    JD.at [ "target", "scrollTop" ] JD.int |> JD.map Model
+    JD.at [ "target", "scrollTop" ] JD.float |> JD.map round |> JD.map Model
 
 
 decodeScroll : (Model -> msg) -> JD.Decoder msg


### PR DESCRIPTION
Hello,

Thanks for this module!

I've found that we've had some strange behavior when scrolling a really small length or sometimes when scrolling fast.
It seems that the `event.target.scrollTop` is not always an `Int` but can also be a `Float`.

By default, I've changed  the decoder to accept a `Float` and then `round` it. I'm unsure if `round` is  the proper function or if we need to use `floor` or `ceiling`, let me know if it's the case, I can update my PR.