### PR TITLE
Add the option to keep the first items in a list in view

### DIFF
--- a/examples/WithStickyHeaderConstantItemHeight.elm
+++ b/examples/WithStickyHeaderConstantItemHeight.elm
@@ -1,0 +1,98 @@
+module WithStickyHeaderConstantItemHeight exposing (main)
+
+import Browser
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (style)
+import InfiniteList as IL
+
+
+type Msg
+    = InfListMsg IL.Model
+
+
+type alias Model =
+    { infList : IL.Model
+    , content : List ListItem
+    }
+
+
+main : Program () Model Msg
+main =
+    Browser.sandbox
+        { init = initModel
+        , view = view
+        , update = update
+        }
+
+
+type ListItem
+    = Header
+    | Row String
+
+
+initModel : Model
+initModel =
+    { infList = IL.init
+    , content = List.range 0 1000 |> List.map String.fromInt |> List.map Row
+    }
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        InfListMsg infList ->
+            { model | infList = infList }
+
+
+
+itemHeight : Int
+itemHeight  =
+    20
+
+
+containerHeight : Int
+containerHeight =
+    500
+
+
+config : IL.Config ListItem Msg
+config =
+    IL.config
+        { itemView = itemView
+        , itemHeight = IL.withConstantHeight itemHeight
+        , containerHeight = containerHeight
+        }
+        |> IL.withOffset 300
+        |> IL.withKeepFirst 1
+
+
+itemView : Int -> Int -> ListItem -> Html Msg
+itemView idx listIdx item =
+    case item of
+        Header ->
+            div
+                [ style "height" (String.fromInt itemHeight ++ "px")
+                , style "position" "sticky"
+                , style "top" "0px"
+                , style "background" "white"
+                ]
+                [ text "Number" ]
+
+        Row val ->
+            div
+                [ style "height" (String.fromInt itemHeight ++ "px")
+                ]
+                [ text val ]
+
+
+view : Model -> Html Msg
+view model =
+    div
+        [ style "height" (String.fromInt containerHeight ++ "px")
+        , style "width" "500px"
+        , style "overflow" "auto"
+        , style "border" "1px solid #000"
+        , style "margin" "auto"
+        , IL.onScroll InfListMsg
+        ]
+        [ IL.view config model.infList (Header :: model.content) ]

--- a/examples/WithStickyHeaderVariableItemHeight.elm
+++ b/examples/WithStickyHeaderVariableItemHeight.elm
@@ -1,0 +1,100 @@
+module WithStickyHeaderVariableItemHeight exposing (main)
+
+import Browser
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (style)
+import InfiniteList as IL
+
+
+type Msg
+    = InfListMsg IL.Model
+
+
+type alias Model =
+    { infList : IL.Model
+    , content : List ListItem
+    }
+
+
+main : Program () Model Msg
+main =
+    Browser.sandbox
+        { init = initModel
+        , view = view
+        , update = update
+        }
+
+
+type ListItem
+    = Header
+    | Row String
+
+
+initModel : Model
+initModel =
+    { infList = IL.init
+    , content = List.range 0 1000 |> List.map String.fromInt |> List.map Row
+    }
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        InfListMsg infList ->
+            { model | infList = infList }
+
+
+
+itemHeight : Int -> ListItem -> Int
+itemHeight _ item =
+    case item of
+        Header -> 30
+        Row _ -> 20
+
+
+containerHeight : Int
+containerHeight =
+    500
+
+
+config : IL.Config ListItem Msg
+config =
+    IL.config
+        { itemView = itemView
+        , itemHeight = IL.withVariableHeight itemHeight
+        , containerHeight = containerHeight
+        }
+        |> IL.withOffset 300
+        |> IL.withKeepFirst 1
+
+
+itemView : Int -> Int -> ListItem -> Html Msg
+itemView idx listIdx item =
+    case item of
+        Header ->
+            div
+                [ style "height" (String.fromInt (itemHeight idx item) ++ "px")
+                , style "position" "sticky"
+                , style "top" "0px"
+                , style "background" "white"
+                ]
+                [ text "Number" ]
+
+        Row val ->
+            div
+                [ style "height" (String.fromInt (itemHeight idx item) ++ "px")
+                ]
+                [ text val ]
+
+
+view : Model -> Html Msg
+view model =
+    div
+        [ style "height" (String.fromInt containerHeight ++ "px")
+        , style "width" "500px"
+        , style "overflow" "auto"
+        , style "border" "1px solid #000"
+        , style "margin" "auto"
+        , IL.onScroll InfListMsg
+        ]
+        [ IL.view config model.infList (Header :: model.content) ]

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -4,7 +4,7 @@
         ".",
         "../src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "FabienHenon/elm-infinite-scroll": "3.0.1",


### PR DESCRIPTION
We want to use this library to view a table, and keep a table header always in view.

One option would be to have this header as a separate div above the infinite list div, however this complicates things considerably when you need to do horizontal scrolling. We have done this in javascript/elm before, and it just isn't as reliable and performant as just being able to use sticky.

Naturally, when you add the first  row as sticky, that works, until the library decides it should no longer render it. That's when I made this change locally, to allow me to always render this first row. You simply add `withKeepFirst 1` to the configuration, and the result is exactly what I was looking for.

I added two new examples that showcase how to use this property, and that it works, both with constant and variable item heights.